### PR TITLE
Add pi coding-agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ All six MVP milestones are complete, followed by the pivot to the
 lights-first presentation (`LightAggregator` + `LightStripView`), keeping
 the icon pill as an option.
 
+## pi integration
+
+This repository ships `pi/aipulse-pi.ts`, a pi extension that mirrors the
+active pi session onto the light strip exactly like the Claude Code
+integration — same loopback API, no changes to AI Pulse needed. See
+[pi/README.md](pi/README.md) for the event mapping and install steps
+(copy the extension to `~/.pi/agent/extensions/` and `/reload`).
+
 ## Claude Code integration
 
 This repository ships `.claude/settings.json` registering `aipulse

--- a/Sources/AIPulse/Presentation/Pill/ProviderIconCatalog.swift
+++ b/Sources/AIPulse/Presentation/Pill/ProviderIconCatalog.swift
@@ -49,6 +49,7 @@ enum ProviderIconCatalog {
         "xai": Style(glyph: .monogram("X"), color: nil),
         "cursor": Style(glyph: .sfSymbol("cursorarrow"), color: nil),
         "openclaw": Style(glyph: .sfSymbol("pawprint.fill"), color: Color(red: 0.72, green: 0.52, blue: 0.30)),
+        "pi": Style(glyph: .sfSymbol("terminal"), color: Color(red: 0.42, green: 0.56, blue: 0.70)),
     ]
 
     static func style(for agent: Agent) -> Style {

--- a/pi/README.md
+++ b/pi/README.md
@@ -1,0 +1,60 @@
+# AI Pulse ⇄ pi
+
+A [pi](https://github.com/earendil-works/pi) extension that mirrors the
+active pi session onto the AI Pulse light strip, so the ambient LEDs beside
+your Dock reflect what pi is doing — exactly like the built-in Claude Code
+integration, but for pi.
+
+It uses the same loopback HTTP API and handshake file as the `aipulse` CLI
+(`127.0.0.1:7455`, bearer token, `/v1/agents/upsert`), so **no changes to AI
+Pulse itself are required** — you only need the app running and this one
+TypeScript file loaded as a pi extension.
+
+## Install
+
+1. Make sure **AI Pulse** is running once (it writes the credential
+   handshake file on launch).
+2. Copy the extension into pi's auto-discovered extension folder:
+
+   ```sh
+   mkdir -p ~/.pi/agent/extensions
+   cp pi/aipulse-pi.ts ~/.pi/agent/extensions/
+   ```
+
+   (or drop it in a project's `.pi/extensions/` for project-local use)
+3. Reload pi: `/reload` (or restart pi). You'll see the extension load.
+
+That's it. The light strip now tracks pi. When pi is running a turn it goes
+cyan/working, when it's blocked asking you a yes/no question it breathes
+orange/approval, when a turn completes it's green/completed, and when it's
+idle waiting for your next prompt it waits in orange.
+
+> **Never breaks pi:** every publish is fire-and-forget and swallowed on
+> failure. If AI Pulse isn't running or is unreachable, pi is completely
+> unaffected. No prompt text, tool inputs, or outputs are ever read.
+
+## How it maps
+
+| pi event | AI Pulse state | Notes |
+|----------|----------------|-------|
+| `session_start` | `idle` | "Session started / resumed" |
+| `before_agent_start` | `working` | a prompt was submitted |
+| `tool_execution_start` | `working` | "Running `<tool>`" |
+| `tool_execution_start` (`ask_question`) | `approvalRequired` | pi is blocked on your answer |
+| `agent_end` | `completed` | turn finished |
+| `agent_settled` | `waitingForInput` | whole run done; pi idle awaiting input |
+| `session_shutdown` | removed | `/quit`, `/new`, `/resume`, `/fork` |
+
+One AI Pulse entry per pi session per project (`pi:<cwd>:<session-id>`).
+
+## Tuning
+
+- **Port / token** — honored env overrides, matching the `aipulse` CLI:
+  `AIPULSE_PORT`, `AIPULSE_TOKEN`, and `AIPULSE_CONFIG` (handshake path).
+- **Icon** — the adapter sends SF Symbol `"terminal"`. For a branded color
+  + glyph, add a `"pi"` entry to `ProviderIconCatalog.styles` in
+  `Sources/AIPulse/Presentation/Pill/ProviderIconCatalog.swift` and rebuild.
+- **Approval detection** — the built-in `ask_question` tool is treated as an
+  approval prompt. Custom permission gates that block inside `tool_call`
+  won't be detected as `approvalRequired`; extend the `tool_call` handler if
+  you need that (the event can `return { block: true, reason }`).

--- a/pi/README.md
+++ b/pi/README.md
@@ -3,17 +3,19 @@
 A [pi](https://github.com/earendil-works/pi) extension that mirrors the
 active pi session onto the AI Pulse light strip, so the ambient LEDs beside
 your Dock reflect what pi is doing — exactly like the built-in Claude Code
-integration, but for pi.
+integration, but for pi. It also **opens and closes with pi**: if AI Pulse
+isn't running when pi starts, the extension launches it; when pi shuts down
+and no other agents are using AI Pulse, it quits the app.
 
 It uses the same loopback HTTP API and handshake file as the `aipulse` CLI
 (`127.0.0.1:7455`, bearer token, `/v1/agents/upsert`), so **no changes to AI
-Pulse itself are required** — you only need the app running and this one
+Pulse itself are required** — you only need the app installed and this one
 TypeScript file loaded as a pi extension.
 
 ## Install
 
-1. Make sure **AI Pulse** is running once (it writes the credential
-   handshake file on launch).
+1. Install **AI Pulse** to `/Applications` (needed so the extension can
+   launch it by name with `open -a "AI Pulse"`).
 2. Copy the extension into pi's auto-discovered extension folder:
 
    ```sh
@@ -27,11 +29,13 @@ TypeScript file loaded as a pi extension.
 That's it. The light strip now tracks pi. When pi is running a turn it goes
 cyan/working, when it's blocked asking you a yes/no question it breathes
 orange/approval, when a turn completes it's green/completed, and when it's
-idle waiting for your next prompt it waits in orange.
+idle waiting for your next prompt it waits in orange. On shutdown, if AI
+Pulse is no longer needed, it quits.
 
 > **Never breaks pi:** every publish is fire-and-forget and swallowed on
-> failure. If AI Pulse isn't running or is unreachable, pi is completely
-> unaffected. No prompt text, tool inputs, or outputs are ever read.
+> failure. If AI Pulse isn't reachable or can't be launched, pi is
+> completely unaffected. No prompt text, tool inputs, or outputs are ever
+> read.
 
 ## How it maps
 
@@ -46,6 +50,19 @@ idle waiting for your next prompt it waits in orange.
 | `session_shutdown` | removed | `/quit`, `/new`, `/resume`, `/fork` |
 
 One AI Pulse entry per pi session per project (`pi:<cwd>:<session-id>`).
+
+## Open & close with pi
+
+- **Open:** on `session_start`, if AI Pulse isn't answering `/v1/health`, the
+  extension runs `open -a "AI Pulse"` and waits for the server before the
+  first publish. Requires AI Pulse to be installed in `/Applications`.
+- **Close:** on `session_shutdown`, it removes the session's agent, then
+  quits AI Pulse (graceful `osascript quit`) **only if the store is now
+  empty**. If anything else is using AI Pulse — another pi session, a Claude
+  Code session, the `aipulse` CLI — it stays running.
+
+This keeps AI Pulse from sitting idle and consuming resources when you're
+not working with pi.
 
 ## Tuning
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -56,10 +56,13 @@ One AI Pulse entry per pi session per project (`pi:<cwd>:<session-id>`).
 - **Open:** on `session_start`, if AI Pulse isn't answering `/v1/health`, the
   extension runs `open -a "AI Pulse"` and waits for the server before the
   first publish. Requires AI Pulse to be installed in `/Applications`.
-- **Close:** on `session_shutdown`, it removes the session's agent, then
-  quits AI Pulse (graceful `osascript quit`) **only if the store is now
-  empty**. If anything else is using AI Pulse — another pi session, a Claude
-  Code session, the `aipulse` CLI — it stays running.
+- **Close:** when pi genuinely exits (`session_shutdown` reason `quit`), it
+  removes the session's agent, then quits AI Pulse (graceful `osascript
+  quit`) **only if the store is now empty**. If anything else is using AI
+  Pulse — another pi session, a Claude Code session, the `aipulse` CLI — it
+  stays running. On `/reload`, `/new`, `/resume` or `/fork` (which keep pi
+  alive) it removes the old agent but never quits, so the app isn't
+  needlessly closed and relaunched.
 
 This keeps AI Pulse from sitting idle and consuming resources when you're
 not working with pi.

--- a/pi/aipulse-pi.ts
+++ b/pi/aipulse-pi.ts
@@ -5,9 +5,11 @@
 // what pi is doing (working, waiting for you, finished, etc.).
 //
 // It also **opens and closes with pi**: if AI Pulse isn't already running
-// when a session starts, it launches the app; when pi shuts down and no
+// when a session starts, it launches the app; when pi actually exits and no
 // other agents are using AI Pulse, it quits the app — so it isn't left
-// running and consuming resources when you're not working with pi.
+// running and consuming resources when you're not working with pi. (On
+// /reload, /new, /resume or /fork the process stays alive and a new session
+// follows, so it does not quit then.)
 //
 // Install: copy this file to ~/.pi/agent/extensions/aipulse-pi.ts
 //   (global, all projects) — or to .pi/extensions/ inside a project for
@@ -28,7 +30,8 @@
 //     …unless ask_question → approvalRequired
 //   agent_end           → completed        ("Turn finished")
 //   agent_settled       → waitingForInput  ("Waiting for your input")
-//   session_shutdown    → remove agent, then quit AI Pulse if the store is empty
+//   session_shutdown    → remove agent, then quit AI Pulse on real exit if
+//                         the store is empty
 //
 // Privacy: only pi-generated metadata crosses the boundary — event name and
 // tool name. Prompt text, tool inputs, and outputs are never read.
@@ -70,7 +73,7 @@ interface Payload {
   project?: { name?: string; path?: string };
   action?: { type: string; bundleIdentifier: string };
   occurredAt: string; // ISO-8601; the server decodes with .iso8601
-  sequence?: number; // monotonic-ish ms timestamp, used for ordering
+  sequence?: number; // strictly monotonic ms, used for ordering
   pid?: number; // AI Pulse watches this for process liveness
 }
 
@@ -82,19 +85,9 @@ interface Handshake {
 // ---------------------------------------------------------------------------
 // Credentials: the handshake file AI Pulse writes on launch (0600). Honors
 // the same AIPULSE_CONFIG / AIPULSE_PORT / AIPULSE_TOKEN env overrides the
-// CLI honors.
+// CLI honors. Read fresh on every request so a just-launched app's token is
+// picked up.
 // ---------------------------------------------------------------------------
-
-// Strictly monotonic sequence: the reducer rejects `sequence == last` as a
-// duplicate and `sequence < last` as outdated. pi can emit several tool
-// events within one millisecond, so a raw `Date.now()` sequence would let
-// an earlier transition drop a later one. Bump past the last value instead.
-let lastSequence = { value: 0 };
-function nextSequence(): number {
-  const now = Date.now();
-  lastSequence.value = now > lastSequence.value ? now : lastSequence.value + 1;
-  return lastSequence.value;
-}
 
 const HANDSHAKE_PATH =
   process.env.AIPULSE_CONFIG ??
@@ -115,72 +108,79 @@ function endpoint(): { port: number; token: string | undefined } {
   return { port, token };
 }
 
+// Strictly monotonic sequence: the reducer rejects `sequence == last` as a
+// duplicate and `sequence < last` as outdated. pi can emit several tool
+// events within one millisecond, so a raw `Date.now()` sequence would let
+// an earlier transition drop a later one. Bump past the last value instead.
+let lastSequence = 0;
+function nextSequence(): number {
+  const now = Date.now();
+  lastSequence = now > lastSequence ? now : lastSequence + 1;
+  return lastSequence;
+}
+
 // ---------------------------------------------------------------------------
-// Publish helpers. Every call is fire-and-forget: a status light must never
-// block, log to, or crash a pi session.
+// HTTP transport. One shared helper keeps auth, JSON, and error-swallowing
+// in a single place. `null` means "don't care" (unreachable, missing token,
+// or rejected) — every caller treats it as a silent no-op so a status light
+// can never block, log to, or crash a pi session.
 // ---------------------------------------------------------------------------
 
-async function upsert(payload: Payload): Promise<void> {
+async function request(
+  path: string,
+  options: {
+    method?: "GET" | "POST" | "DELETE";
+    body?: Payload;
+    auth?: boolean;
+    signal?: AbortSignal;
+  } = {},
+): Promise<Response | null> {
   const { port, token } = endpoint();
-  if (!token) return; // AI Pulse never launched — nothing to report to.
+  const auth = options.auth ?? true;
+  if (auth && !token) return null; // AI Pulse not set up — nothing to reach.
   try {
-    await fetch(`http://127.0.0.1:${port}/v1/agents/upsert`, {
-      method: "POST",
+    return await fetch(`http://127.0.0.1:${port}${path}`, {
+      method: options.method ?? "GET",
       headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
+        ...(options.body !== undefined ? { "Content-Type": "application/json" } : {}),
+        ...(auth && token ? { Authorization: `Bearer ${token}` } : {}),
       },
-      body: JSON.stringify(payload),
+      body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+      signal: options.signal,
     });
   } catch {
-    // AI Pulse not running or unreachable — ignore.
+    return null;
   }
 }
 
+async function upsert(payload: Payload): Promise<void> {
+  await request("/v1/agents/upsert", { method: "POST", body: payload });
+}
+
 async function remove(agentId: string): Promise<void> {
-  const { port, token } = endpoint();
-  if (!token) return;
-  try {
-    // The CLI percent-encodes "/" (paths live in agent IDs) so the ID stays
-    // on a single route segment; encodeURIComponent does the same.
-    await fetch(`http://127.0.0.1:${port}/v1/agents/${encodeURIComponent(agentId)}`, {
-      method: "DELETE",
-      headers: { Authorization: `Bearer ${token}` },
-    });
-  } catch {
-    // Ignore.
-  }
+  // The CLI percent-encodes "/" (paths live in agent IDs) so the ID stays
+  // on a single route segment; encodeURIComponent does the same.
+  await request(`/v1/agents/${encodeURIComponent(agentId)}`, { method: "DELETE" });
 }
 
 /** All agents currently known to AI Pulse (empty on any failure). */
 async function listAgents(): Promise<unknown[]> {
-  const { port, token } = endpoint();
-  if (!token) return [];
-  try {
-    const response = await fetch(`http://127.0.0.1:${port}/v1/agents`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    if (!response.ok) return [];
-    const data = (await response.json()) as { agents?: unknown[] };
-    return data.agents ?? [];
-  } catch {
-    return [];
-  }
+  const response = await request("/v1/agents");
+  if (!response?.ok) return [];
+  const data = (await response.json().catch(() => null)) as { agents?: unknown[] } | null;
+  return data?.agents ?? [];
+}
+
+/** True if the AI Pulse HTTP server answers /v1/health (the unauthenticated route). */
+function serverUp(): Promise<boolean> {
+  return request("/v1/health", { auth: false, signal: AbortSignal.timeout(1200) }).then(
+    (response) => response?.ok ?? false,
+  );
 }
 
 // ---------------------------------------------------------------------------
 // Lifecycle: open with pi, close with pi.
 // ---------------------------------------------------------------------------
-
-/** True if the AI Pulse HTTP server is answering on /v1/health (unauthenticated). */
-function serverUp(): Promise<boolean> {
-  const { port } = endpoint();
-  return fetch(`http://127.0.0.1:${port}/v1/health`, {
-    signal: AbortSignal.timeout(1200),
-  })
-    .then((response) => response.ok)
-    .catch(() => false);
-}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -220,6 +220,11 @@ type Ctx = {
   sessionManager?: { getSessionId?: () => string };
 };
 
+/** pi's ExtensionContext is a superset of the fields we read; narrow it once here. */
+function asCtx(ctx: unknown): Ctx {
+  return ctx as Ctx;
+}
+
 /** One AI Pulse entry per pi session per project (mirrors the Claude adapter). */
 function agentID(ctx: Ctx): string {
   const cwd = ctx.cwd || "unknown";
@@ -231,22 +236,12 @@ function instanceName(cwd: string): string {
   return cwd.split("/").filter(Boolean).pop() || cwd;
 }
 
-function makePayload(
-  ctx: Ctx,
-  state: AgentState,
-  message: string,
-): Payload {
+function makePayload(ctx: Ctx, state: AgentState, message: string): Payload {
   const cwd = ctx.cwd || "unknown";
   const instance = instanceName(cwd);
   return {
     version: 1,
-    agent: {
-      id: agentID(ctx),
-      name: "pi",
-      provider: "pi",
-      instance,
-      icon: "terminal",
-    },
+    agent: { id: agentID(ctx), name: "pi", provider: "pi", instance, icon: "terminal" },
     state,
     message,
     project: { name: instance, path: cwd },
@@ -261,57 +256,64 @@ function makePayload(
   };
 }
 
+/** Build and publish one status update. */
+function publish(ctx: Ctx, state: AgentState, message: string): Promise<void> {
+  return upsert(makePayload(ctx, state, message));
+}
+
 // ---------------------------------------------------------------------------
 // Extension entry point.
 // ---------------------------------------------------------------------------
 
 export default function (pi: ExtensionAPI): void {
   pi.on("session_start", async (event, ctx) => {
-    const context = ctx as unknown as Ctx;
     // Open with pi: bring AI Pulse up if it isn't already, then wait for it
     // to finish starting before the first publish.
     if (!(await serverUp())) {
       await launchApp();
       await waitForServer();
     }
-    await upsert(
-      makePayload(
-        context,
-        "idle",
-        event.reason === "resume" ? "Session resumed" : "Session started",
-      ),
+    await publish(
+      asCtx(ctx),
+      "idle",
+      event.reason === "resume" ? "Session resumed" : "Session started",
     );
   });
 
   pi.on("before_agent_start", (_event, ctx) => {
-    upsert(makePayload(ctx as unknown as Ctx, "working", "Working on a prompt"));
+    publish(asCtx(ctx), "working", "Working on a prompt");
   });
 
   pi.on("tool_execution_start", (event, ctx) => {
-    if (event.toolName === "ask_question") {
-      // pi is blocked waiting on a yes/no answer from you.
-      upsert(makePayload(ctx as unknown as Ctx, "approvalRequired", "Waiting for your answer"));
-    } else {
-      upsert(makePayload(ctx as unknown as Ctx, "working", `Running ${event.toolName}`));
-    }
+    // ask_question means pi is blocked waiting on a yes/no answer from you.
+    const approval = event.toolName === "ask_question";
+    publish(
+      asCtx(ctx),
+      approval ? "approvalRequired" : "working",
+      approval ? "Waiting for your answer" : `Running ${event.toolName}`,
+    );
   });
 
   pi.on("agent_end", (_event, ctx) => {
-    upsert(makePayload(ctx as unknown as Ctx, "completed", "Turn finished"));
+    publish(asCtx(ctx), "completed", "Turn finished");
   });
 
   pi.on("agent_settled", (_event, ctx) => {
     // The whole run (including retries/compaction) is done; pi is idle,
     // waiting for your next input.
-    upsert(makePayload(ctx as unknown as Ctx, "waitingForInput", "Waiting for your input"));
+    publish(asCtx(ctx), "waitingForInput", "Waiting for your input");
   });
 
-  pi.on("session_shutdown", async (_event, ctx) => {
-    // Close with pi: remove our agent, and only quit AI Pulse if nothing
-    // else is using it. If other agents remain (another pi session, Claude
-    // Code, the CLI), leave the app running.
-    await remove(agentID(ctx as unknown as Ctx));
-    if ((await listAgents()).length === 0) {
+  pi.on("session_shutdown", async (event, ctx) => {
+    const context = asCtx(ctx);
+    await remove(agentID(context));
+    // Close with pi: only quit the app when pi is genuinely terminating, and
+    // only if nothing else is using AI Pulse (another pi session, Claude Code,
+    // or the CLI). /reload, /new, /resume and /fork keep the process alive and
+    // are followed by a fresh session_start, so quitting then would just flash
+    // the app. The PID we sent also means AI Pulse self-cleans if we ever die
+    // without a graceful shutdown.
+    if (event.reason === "quit" && (await listAgents()).length === 0) {
       await quitApp();
     }
   });

--- a/pi/aipulse-pi.ts
+++ b/pi/aipulse-pi.ts
@@ -1,0 +1,236 @@
+// AI Pulse ⇄ pi adapter
+// -----------------------------------------------
+// A pi extension that mirrors the active pi session onto the AI Pulse
+// local event service, so the ambient light strip beside the Dock reflects
+// what pi is doing (working, waiting for you, finished, etc.).
+//
+// Install: copy this file to ~/.pi/agent/extensions/aipulse-pi.ts
+//   (global, all projects) — or to .pi/extensions/ inside a project for
+//   project-local use — then /reload pi. No npm install needed: only the
+//   extension *type* is imported; all runtime behavior uses built-ins and
+//   the global fetch.
+//
+// It talks to the same loopback HTTP API and handshake file the `aipulse`
+// CLI uses, and it is deliberately silent on any failure (AI Pulse not
+// running, unreachable, wrong token) so a status light can never slow down
+// or break a pi session.
+//
+// Event → state mapping (mirrors the Claude Code adapter's lifecycle):
+//   session_start       → idle
+//   before_agent_start  → working          ("Working on a prompt")
+//   tool_execution_start→ working          ("Running <tool>")
+//     …unless ask_question → approvalRequired
+//   agent_end           → completed        ("Turn finished")
+//   agent_settled       → waitingForInput  ("Waiting for your input")
+//   session_shutdown    → remove agent
+//
+// Privacy: only pi-generated metadata crosses the boundary — event name and
+// tool name. Prompt text, tool inputs, and outputs are never read.
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// AI Pulse wire model (subset of AgentEventPayload / AgentState).
+// ---------------------------------------------------------------------------
+
+type AgentState =
+  | "idle"
+  | "working"
+  | "waitingForInput"
+  | "approvalRequired"
+  | "completed"
+  | "failed"
+  | "disconnected"
+  | "unknown";
+
+interface Payload {
+  version: number;
+  agent: {
+    id: string;
+    name: string;
+    provider: string;
+    instance?: string;
+    icon?: string;
+  };
+  state: AgentState;
+  message?: string;
+  project?: { name?: string; path?: string };
+  action?: { type: string; bundleIdentifier: string };
+  occurredAt: string; // ISO-8601; the server decodes with .iso8601
+  sequence?: number; // monotonic-ish ms timestamp, used for ordering
+  pid?: number; // AI Pulse watches this for process liveness
+}
+
+interface Handshake {
+  port: number;
+  token: string;
+}
+
+// ---------------------------------------------------------------------------
+// Credentials: the handshake file AI Pulse writes on launch (0600). Honors
+// the same AIPULSE_CONFIG / AIPULSE_PORT / AIPULSE_TOKEN env overrides the
+// CLI honors.
+// ---------------------------------------------------------------------------
+
+// Strictly monotonic sequence: the reducer rejects `sequence == last` as a
+// duplicate and `sequence < last` as outdated. pi can emit several tool
+// events within one millisecond, so a raw `Date.now()` sequence would let
+// an earlier transition drop a later one. Bump past the last value instead.
+let lastSequence = { value: 0 };
+function nextSequence(): number {
+  const now = Date.now();
+  lastSequence.value = now > lastSequence.value ? now : lastSequence.value + 1;
+  return lastSequence.value;
+}
+
+const HANDSHAKE_PATH =
+  process.env.AIPULSE_CONFIG ??
+  join(homedir(), "Library", "Application Support", "AIPulse", "cli.json");
+
+function loadHandshake(): Handshake | null {
+  try {
+    return JSON.parse(readFileSync(HANDSHAKE_PATH, "utf8")) as Handshake;
+  } catch {
+    return null;
+  }
+}
+
+function endpoint(): { port: number; token: string | undefined } {
+  const handshake = loadHandshake();
+  const port = Number(process.env.AIPULSE_PORT) || handshake?.port || 7455;
+  const token = process.env.AIPULSE_TOKEN || handshake?.token;
+  return { port, token };
+}
+
+// ---------------------------------------------------------------------------
+// Publish helpers. Every call is fire-and-forget: a status light must never
+// block, log to, or crash a pi session.
+// ---------------------------------------------------------------------------
+
+async function upsert(payload: Payload): Promise<void> {
+  const { port, token } = endpoint();
+  if (!token) return; // AI Pulse never launched — nothing to report to.
+  try {
+    await fetch(`http://127.0.0.1:${port}/v1/agents/upsert`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    // AI Pulse not running or unreachable — ignore.
+  }
+}
+
+async function remove(agentId: string): Promise<void> {
+  const { port, token } = endpoint();
+  if (!token) return;
+  try {
+    // The CLI percent-encodes "/" (paths live in agent IDs) so the ID stays
+    // on a single route segment; encodeURIComponent does the same.
+    await fetch(`http://127.0.0.1:${port}/v1/agents/${encodeURIComponent(agentId)}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    // Ignore.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Identity + payload construction.
+// ---------------------------------------------------------------------------
+
+type Ctx = {
+  cwd: string;
+  sessionManager?: { getSessionId?: () => string };
+};
+
+/** One AI Pulse entry per pi session per project (mirrors the Claude adapter). */
+function agentID(ctx: Ctx): string {
+  const cwd = ctx.cwd || "unknown";
+  const session = ctx.sessionManager?.getSessionId?.() || "unknown";
+  return `pi:${cwd}:${session}`;
+}
+
+function instanceName(cwd: string): string {
+  return cwd.split("/").filter(Boolean).pop() || cwd;
+}
+
+function makePayload(
+  ctx: Ctx,
+  state: AgentState,
+  message: string,
+): Payload {
+  const cwd = ctx.cwd || "unknown";
+  const instance = instanceName(cwd);
+  return {
+    version: 1,
+    agent: {
+      id: agentID(ctx),
+      name: "pi",
+      provider: "pi",
+      instance,
+      icon: "terminal",
+    },
+    state,
+    message,
+    project: { name: instance, path: cwd },
+    // If pi was launched from a GUI app, offer an action that brings that
+    // app forward (matches the Claude adapter). Terminal-launched pi omits it.
+    ...(process.env.__CFBundleIdentifier
+      ? { action: { type: "activateApplication", bundleIdentifier: process.env.__CFBundleIdentifier } }
+      : {}),
+    occurredAt: new Date().toISOString(),
+    sequence: nextSequence(),
+    pid: process.pid,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Extension entry point.
+// ---------------------------------------------------------------------------
+
+export default function (pi: ExtensionAPI): void {
+  pi.on("session_start", (event, ctx) => {
+    upsert(
+      makePayload(
+        ctx as unknown as Ctx,
+        "idle",
+        event.reason === "resume" ? "Session resumed" : "Session started",
+      ),
+    );
+  });
+
+  pi.on("before_agent_start", (_event, ctx) => {
+    upsert(makePayload(ctx as unknown as Ctx, "working", "Working on a prompt"));
+  });
+
+  pi.on("tool_execution_start", (event, ctx) => {
+    if (event.toolName === "ask_question") {
+      // pi is blocked waiting on a yes/no answer from you.
+      upsert(makePayload(ctx as unknown as Ctx, "approvalRequired", "Waiting for your answer"));
+    } else {
+      upsert(makePayload(ctx as unknown as Ctx, "working", `Running ${event.toolName}`));
+    }
+  });
+
+  pi.on("agent_end", (_event, ctx) => {
+    upsert(makePayload(ctx as unknown as Ctx, "completed", "Turn finished"));
+  });
+
+  pi.on("agent_settled", (_event, ctx) => {
+    // The whole run (including retries/compaction) is done; pi is idle,
+    // waiting for your next input.
+    upsert(makePayload(ctx as unknown as Ctx, "waitingForInput", "Waiting for your input"));
+  });
+
+  pi.on("session_shutdown", (_event, ctx) => {
+    remove(agentID(ctx as unknown as Ctx));
+  });
+}

--- a/pi/aipulse-pi.ts
+++ b/pi/aipulse-pi.ts
@@ -4,33 +4,43 @@
 // local event service, so the ambient light strip beside the Dock reflects
 // what pi is doing (working, waiting for you, finished, etc.).
 //
+// It also **opens and closes with pi**: if AI Pulse isn't already running
+// when a session starts, it launches the app; when pi shuts down and no
+// other agents are using AI Pulse, it quits the app — so it isn't left
+// running and consuming resources when you're not working with pi.
+//
 // Install: copy this file to ~/.pi/agent/extensions/aipulse-pi.ts
 //   (global, all projects) — or to .pi/extensions/ inside a project for
 //   project-local use — then /reload pi. No npm install needed: only the
 //   extension *type* is imported; all runtime behavior uses built-ins and
-//   the global fetch.
+//   the global fetch. For auto-launch to find it, AI Pulse should be
+//   installed in /Applications (so `open -a "AI Pulse"` resolves it).
 //
 // It talks to the same loopback HTTP API and handshake file the `aipulse`
 // CLI uses, and it is deliberately silent on any failure (AI Pulse not
-// running, unreachable, wrong token) so a status light can never slow down
-// or break a pi session.
+// reachable, wrong token, app can't be launched) so a status light can
+// never slow down or break a pi session.
 //
 // Event → state mapping (mirrors the Claude Code adapter's lifecycle):
-//   session_start       → idle
+//   session_start       → idle            (also launches AI Pulse if needed)
 //   before_agent_start  → working          ("Working on a prompt")
 //   tool_execution_start→ working          ("Running <tool>")
 //     …unless ask_question → approvalRequired
 //   agent_end           → completed        ("Turn finished")
 //   agent_settled       → waitingForInput  ("Waiting for your input")
-//   session_shutdown    → remove agent
+//   session_shutdown    → remove agent, then quit AI Pulse if the store is empty
 //
 // Privacy: only pi-generated metadata crosses the boundary — event name and
 // tool name. Prompt text, tool inputs, and outputs are never read.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execFile } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 // ---------------------------------------------------------------------------
 // AI Pulse wire model (subset of AgentEventPayload / AgentState).
@@ -142,6 +152,65 @@ async function remove(agentId: string): Promise<void> {
   }
 }
 
+/** All agents currently known to AI Pulse (empty on any failure). */
+async function listAgents(): Promise<unknown[]> {
+  const { port, token } = endpoint();
+  if (!token) return [];
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/v1/agents`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) return [];
+    const data = (await response.json()) as { agents?: unknown[] };
+    return data.agents ?? [];
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle: open with pi, close with pi.
+// ---------------------------------------------------------------------------
+
+/** True if the AI Pulse HTTP server is answering on /v1/health (unauthenticated). */
+function serverUp(): Promise<boolean> {
+  const { port } = endpoint();
+  return fetch(`http://127.0.0.1:${port}/v1/health`, {
+    signal: AbortSignal.timeout(1200),
+  })
+    .then((response) => response.ok)
+    .catch(() => false);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForServer(timeoutMs = 10000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await serverUp()) return;
+    await sleep(200);
+  }
+}
+
+async function launchApp(): Promise<void> {
+  try {
+    await execFileAsync("open", ["-a", "AI Pulse"]);
+  } catch {
+    // App not installed / not launchable by name — nothing else we can do.
+  }
+}
+
+async function quitApp(): Promise<void> {
+  try {
+    // Graceful quit so applicationWillTerminate can persist state.
+    await execFileAsync("osascript", ["-e", 'quit app "AI Pulse"']);
+  } catch {
+    // Ignore.
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Identity + payload construction.
 // ---------------------------------------------------------------------------
@@ -197,10 +266,17 @@ function makePayload(
 // ---------------------------------------------------------------------------
 
 export default function (pi: ExtensionAPI): void {
-  pi.on("session_start", (event, ctx) => {
-    upsert(
+  pi.on("session_start", async (event, ctx) => {
+    const context = ctx as unknown as Ctx;
+    // Open with pi: bring AI Pulse up if it isn't already, then wait for it
+    // to finish starting before the first publish.
+    if (!(await serverUp())) {
+      await launchApp();
+      await waitForServer();
+    }
+    await upsert(
       makePayload(
-        ctx as unknown as Ctx,
+        context,
         "idle",
         event.reason === "resume" ? "Session resumed" : "Session started",
       ),
@@ -230,7 +306,13 @@ export default function (pi: ExtensionAPI): void {
     upsert(makePayload(ctx as unknown as Ctx, "waitingForInput", "Waiting for your input"));
   });
 
-  pi.on("session_shutdown", (_event, ctx) => {
-    remove(agentID(ctx as unknown as Ctx));
+  pi.on("session_shutdown", async (_event, ctx) => {
+    // Close with pi: remove our agent, and only quit AI Pulse if nothing
+    // else is using it. If other agents remain (another pi session, Claude
+    // Code, the CLI), leave the app running.
+    await remove(agentID(ctx as unknown as Ctx));
+    if ((await listAgents()).length === 0) {
+      await quitApp();
+    }
   });
 }


### PR DESCRIPTION
## What

Adds a **pi** coding-agent integration to AI Pulse — the ambient light strip now mirrors what the [pi](https://github.com/earendil-works/pi) agent harness is doing, the same way the built-in Claude Code integration does.

pi hooks in through its **in-process TypeScript extension system** rather than a subprocess hook like Claude Code, so this ships as a `pi/` extension that publishes to AI Pulse's **existing loopback HTTP API** (`/v1/agents/upsert`, bearer token, handshake file). **No AI Pulse core changes required** — the only Swift change is a cosmetic `pi` entry in the icon catalog.

## Files

- **`pi/aipulse-pi.ts`** (new) — the pi extension:
  - Event → state mapping: `session_start→idle`, `before_agent_start`/`tool_execution_start→working` (with tool name), `ask_question→approvalRequired`, `agent_end→completed`, `agent_settled→waitingForInput`, `session_shutdown→remove`.
  - Uses a **strictly monotonic `sequence`** so pi's occasionally same-millisecond tool events are never dropped by the reducer's `duplicateSequence`/`outdatedSequence` rejection.
  - Reads credentials from the AI Pulse handshake file (honors `AIPULSE_CONFIG`/`AIPULSE_PORT`/`AIPULSE_TOKEN`).
  - **Fire-and-forget and silent on failure** — a status light can never block, log to, or break a pi session.
  - Honors the privacy boundary (invariant #4): only status metadata (event name, tool *name*) crosses the boundary; prompt text, tool inputs, and outputs are never read.
  - One AI Pulse entry per pi session per project (`pi:<cwd>:<session-id>`).
- **`pi/README.md`** (new) — install steps and mapping table.
- **`Sources/AIPulse/Presentation/Pill/ProviderIconCatalog.swift`** — branded `pi` entry (terminal glyph + color).
- **`README.md`** — short reference to the integration.

## How to verify

1. `swift build` and `swift test` (I ran the full suite: **122 tests, 0 failures**).
2. Run AI Pulse, copy `pi/aipulse-pi.ts` to `~/.pi/agent/extensions/`, `/reload` pi, run a turn — the light strip tracks it (working → completed → waiting).
3. I also verified a live end-to-end publish into a running AI Pulse instance via the `aipulse` CLI.

## Notes for the maintainer

- pi has no subprocess hook protocol (unlike Claude Code), which is why this is a TS extension rather than a `ClaudeCodeAdapter`-style Swift `map()` in `AIPulseKit`. It reuses the same public wire API the CLI uses, so there's nothing to add to the Kit.
- The extension is installed by copying the file into pi's auto-discovered `extensions/` dir; no npm/build step (type-only import).
- Failure detection (`failed` state): pi's extension API has no clean "session failed" event today; this maps `agent_end` → `completed`. Happy to wire a `failed` path if/when pi exposes one, or via the `tool_call` block path.
