### PR TITLE
pi: skip the 10s server wait when AI Pulse can't be launched

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -55,7 +55,9 @@ One AI Pulse entry per pi session per project (`pi:<cwd>:<session-id>`).
 
 - **Open:** on `session_start`, if AI Pulse isn't answering `/v1/health`, the
   extension runs `open -a "AI Pulse"` and waits for the server before the
-  first publish. Requires AI Pulse to be installed in `/Applications`.
+  first publish. Requires AI Pulse to be installed in `/Applications`. If the
+  launch fails (AI Pulse missing or renamed), it does **not** wait — the 10s
+  server poll is skipped and pi starts immediately.
 - **Close:** when pi genuinely exits (`session_shutdown` reason `quit`), it
   removes the session's agent, then quits AI Pulse (graceful `osascript
   quit`) **only if the store is now empty**. If anything else is using AI

--- a/pi/aipulse-pi.ts
+++ b/pi/aipulse-pi.ts
@@ -194,11 +194,15 @@ async function waitForServer(timeoutMs = 10000): Promise<void> {
   }
 }
 
-async function launchApp(): Promise<void> {
+/** Launch AI Pulse by name. True if LaunchServices resolved it (i.e. the app
+ *  is installed); false — fast — when it isn't, so callers can skip waiting
+ *  for a server that will never appear. */
+async function launchApp(): Promise<boolean> {
   try {
     await execFileAsync("open", ["-a", "AI Pulse"]);
+    return true;
   } catch {
-    // App not installed / not launchable by name — nothing else we can do.
+    return false; // Not installed / not resolvable by name.
   }
 }
 
@@ -270,8 +274,12 @@ export default function (pi: ExtensionAPI): void {
     // Open with pi: bring AI Pulse up if it isn't already, then wait for it
     // to finish starting before the first publish.
     if (!(await serverUp())) {
-      await launchApp();
-      await waitForServer();
+      // Launch failed (AI Pulse not installed / renamed): don't poll 10s for
+      // a server that can't appear — publish below simply no-ops. On success,
+      // wait for the app to finish booting before the first publish.
+      if (await launchApp()) {
+        await waitForServer();
+      }
     }
     await publish(
       asCtx(ctx),

--- a/pi/aipulse-pi.ts
+++ b/pi/aipulse-pi.ts
@@ -194,9 +194,9 @@ async function waitForServer(timeoutMs = 10000): Promise<void> {
   }
 }
 
-/** Launch AI Pulse by name. True if LaunchServices resolved it (i.e. the app
- *  is installed); false — fast — when it isn't, so callers can skip waiting
- *  for a server that will never appear. */
+/** Launch AI Pulse by name. True if LaunchServices resolved it (i.e. `open -a`
+ *  succeeded); false — fast — when it isn't resolvable by name, so callers can
+ *  skip waiting for a server that will never appear. */
 async function launchApp(): Promise<boolean> {
   try {
     await execFileAsync("open", ["-a", "AI Pulse"]);


### PR DESCRIPTION
Follow-up to #1, addresses #3.

**Problem:** when AI Pulse isn't installed (or isn't resolvable via `open -a "AI Pulse"`), `launchApp()` failed fast but `waitForServer()` still polled its full 10-second timeout — and the `session_start` handler awaited it, so **every pi session start was delayed ~10s** for users with the extension installed but not the app (or with it moved/renamed).

**Fix:** `launchApp()` now reports success/failure. `session_start` only runs `waitForServer()` when the launch succeeded; on failure it does the single `serverUp()` check as before and moves straight on (the first publish simply no-ops, as with any unreachable AI Pulse).

**Docs:** the "Open" section of `pi/README.md` now states the failed-launch case skips the 10s poll.

Related: #2 (separate PR — this one and #2 touch adjacent lines in the `session_start` handler; if both are accepted, whichever merges second needs a trivial rebase — happy to do it).

Fixes #3
