### PR TITLE
Configurable state priority + LED-based per-agent UI

### DIFF
--- a/Scripts/make-app.sh
+++ b/Scripts/make-app.sh
@@ -10,7 +10,11 @@ cd "$(dirname "$0")/.."
 
 CONFIG="${1:-release}"
 APP="dist/AI Pulse.app"
-VERSION="${AIPULSE_VERSION:-0.1.0}"
+# Releases pass AIPULSE_VERSION; local builds stamp the nearest tag (plus
+# commit distance and -dirty) so Settings shows the real version instead of
+# a placeholder.
+VERSION="${AIPULSE_VERSION:-$(git describe --tags --always --dirty 2>/dev/null | sed 's/^v//')}"
+VERSION="${VERSION:-0.0.0}"
 
 # AIPULSE_UNIVERSAL=1 builds a universal (arm64 + x86_64) binary for
 # distribution; the default single-arch build keeps local iteration fast.

--- a/Sources/AIPulse/Application/AppDelegate.swift
+++ b/Sources/AIPulse/Application/AppDelegate.swift
@@ -15,6 +15,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var serverController: ServerController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        store.statePriority = behaviorSettings.statePriorityOrder
         // Restore unresolved states from the previous run; live-only states
         // come back as disconnected until their source reports again.
         let restored = RestorePolicy.rehydrate(persistence.load(), at: Date())

--- a/Sources/AIPulse/Application/AppearanceSettings.swift
+++ b/Sources/AIPulse/Application/AppearanceSettings.swift
@@ -2,7 +2,8 @@ import Foundation
 import Observation
 
 /// What the floating indicator shows: the aggregate LED strip (default) or
-/// per-agent icons.
+/// one light per agent. (`icons` is the historical raw value; the style now
+/// renders per-agent lights.)
 enum IndicatorStyle: String, CaseIterable {
     case lights
     case icons
@@ -10,7 +11,7 @@ enum IndicatorStyle: String, CaseIterable {
     var label: String {
         switch self {
         case .lights: "Lights"
-        case .icons: "Agent icons"
+        case .icons: "Agent lights"
         }
     }
 }

--- a/Sources/AIPulse/Application/BehaviorSettings.swift
+++ b/Sources/AIPulse/Application/BehaviorSettings.swift
@@ -12,10 +12,17 @@ final class BehaviorSettings {
         static let completedRemovalDelay = "behavior.completedRemovalDelay"
         // Stored as seconds; -1 encodes "never disconnect".
         static let workingDisconnectAfter = "behavior.workingDisconnectAfter"
+        // Stored as an ordered array of AgentState raw values.
+        static let statePriority = "behavior.statePriority"
     }
 
     var staleness: StalenessConfiguration {
         didSet { save() }
+    }
+
+    /// Display priority across agent states, most urgent first.
+    var statePriorityOrder: [AgentState] {
+        didSet { defaults.set(statePriorityOrder.map(\.rawValue), forKey: Keys.statePriority) }
     }
 
     private let defaults: UserDefaults
@@ -35,6 +42,11 @@ final class BehaviorSettings {
             config.workingDisconnectAfter = stored < 0 ? nil : stored
         }
         staleness = config
+        if let raw = defaults.stringArray(forKey: Keys.statePriority) {
+            statePriorityOrder = StatusPriority.normalize(raw.compactMap(AgentState.init(rawValue:)))
+        } else {
+            statePriorityOrder = StatusPriority.defaultOrder
+        }
     }
 
     private func save() {

--- a/Sources/AIPulse/Application/PillCoordinator.swift
+++ b/Sources/AIPulse/Application/PillCoordinator.swift
@@ -181,6 +181,12 @@ final class PillCoordinator {
         maintenanceController?.sweepNow()
     }
 
+    /// Pushes the user-arranged display priority into the store; every
+    /// surface (icon sort, lights, Dock tile) re-derives from it.
+    func statePriorityChanged(_ order: [AgentState]) {
+        store.statePriority = StatusPriority.normalize(order)
+    }
+
     /// Dock icon and floating pill are independently toggleable surfaces.
     func presentationChanged(showDockIcon: Bool, showPill: Bool) {
         dockTileController?.setEnabled(showDockIcon)

--- a/Sources/AIPulse/Presentation/DockTile/DockTileController.swift
+++ b/Sources/AIPulse/Presentation/DockTile/DockTileController.swift
@@ -38,7 +38,7 @@ final class DockTileController {
 
     private func refresh() {
         guard enabled else { return }
-        let summary = DockTileAggregator.summarize(store.allSorted)
+        let summary = DockTileAggregator.summarize(store.allSorted, order: store.statePriority)
         guard summary != lastSummary else { return }
         lastSummary = summary
 
@@ -59,6 +59,7 @@ final class DockTileController {
     private func observeStore() {
         withObservationTracking {
             _ = store.agentsByID
+            _ = store.statePriority
         } onChange: { [weak self] in
             Task { @MainActor in
                 guard let self else { return }
@@ -69,51 +70,44 @@ final class DockTileController {
     }
 }
 
-/// Static aggregate rendering: a dark rounded tile with a pill motif and a
-/// status indicator. Rendered on demand by NSDockTile.display(), so state
-/// is conveyed by color + glyph, not animation.
+/// Static aggregate rendering: the app icon with a status indicator in the
+/// corner. Rendered on demand by NSDockTile.display(), so state is conveyed
+/// by color, not animation. (Setting a contentView replaces the Dock's own
+/// icon rendering, so the view draws the icon itself.)
 struct DockTileView: View {
     let summary: DockTileSummary
+
+    /// The bundled icon art, loaded straight from the icns: the system's
+    /// legacy-icon treatment (NSApp.applicationIconImage on macOS 26+) wraps
+    /// non-squircle icons in a gray rounded-square backdrop. Unbundled
+    /// `swift run` builds fall back to the generic application icon.
+    private static let iconImage: NSImage = {
+        if let url = Bundle.main.url(forResource: "AppIcon", withExtension: "icns"),
+           let image = NSImage(contentsOf: url) {
+            return image
+        }
+        return NSApp.applicationIconImage
+    }()
 
     var body: some View {
         GeometryReader { proxy in
             let side = min(proxy.size.width, proxy.size.height)
             ZStack {
-                RoundedRectangle(cornerRadius: side * 0.22)
-                    .fill(
-                        LinearGradient(
-                            colors: [Color(white: 0.22), Color(white: 0.10)],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                    .padding(side * 0.05)
+                Image(nsImage: Self.iconImage)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: side, height: side)
 
-                Capsule()
-                    .fill(Color.white.opacity(0.14))
-                    .overlay(
-                        HStack(spacing: side * 0.045) {
-                            ForEach(0..<3, id: \.self) { _ in
-                                Circle()
-                                    .fill(Color.white.opacity(0.55))
-                                    .frame(width: side * 0.09, height: side * 0.09)
-                            }
-                        }
-                    )
-                    .frame(width: side * 0.56, height: side * 0.26)
-
-                if summary.emphasis != .neutral {
-                    ZStack {
-                        Circle().fill(indicatorColor)
-                        if let glyph = indicatorGlyph {
-                            Image(systemName: glyph)
-                                .font(.system(size: side * 0.12, weight: .bold))
-                                .foregroundStyle(.white)
-                        }
-                    }
-                    .frame(width: side * 0.24, height: side * 0.24)
-                    .overlay(Circle().strokeBorder(Color.black.opacity(0.3), lineWidth: 1))
-                    .offset(x: side * 0.22, y: side * 0.22)
+                // Only working gets a corner dot: attention and failure are
+                // already counted by the numeric badge, so a second marker
+                // for them would be redundant.
+                if summary.emphasis == .working {
+                    Circle()
+                        .fill(indicatorColor)
+                        .frame(width: side * 0.2, height: side * 0.2)
+                        .overlay(Circle().strokeBorder(Color.black.opacity(0.3), lineWidth: 1))
+                        .shadow(color: indicatorColor.opacity(0.7), radius: side * 0.03)
+                        .offset(x: side * 0.26, y: side * 0.26)
                 }
             }
         }
@@ -126,15 +120,6 @@ struct DockTileView: View {
         case .working: .indigo
         case .attention: .orange
         case .failure: .red
-        }
-    }
-
-    private var indicatorGlyph: String? {
-        switch summary.emphasis {
-        case .neutral: nil
-        case .working: "arrow.triangle.2.circlepath"
-        case .attention: "questionmark"
-        case .failure: "exclamationmark"
         }
     }
 

--- a/Sources/AIPulse/Presentation/Pill/AgentLightView.swift
+++ b/Sources/AIPulse/Presentation/Pill/AgentLightView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import AIPulseKit
+
+/// One agent rendered as a single LED — the per-agent counterpart of the
+/// aggregate strip, sharing its palette and animation language. No provider
+/// glyph or state badge: color and motion carry the state, VoiceOver carries
+/// the words.
+///
+/// - working:            the LED pulses cyan
+/// - waiting / approval: breathes orange until acknowledged, then dims solid
+/// - failed:             double-blinks red until acknowledged, then dims solid
+/// - completed:          solid green
+/// - idle / others:      dim static treatments
+struct AgentLightView: View {
+    let agent: Agent
+    var isStale: Bool = false
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    static let diameter: CGFloat = 10
+    /// The LED stays small; the frame keeps a comfortable click target.
+    static let hitSize: CGFloat = 20
+
+    var body: some View {
+        Group {
+            if let tick, !reduceMotion {
+                TimelineView(.periodic(from: .now, by: tick)) { context in
+                    led(at: context.date.timeIntervalSinceReferenceDate)
+                }
+            } else {
+                led(at: nil)
+            }
+        }
+        .frame(width: Self.hitSize, height: Self.hitSize)
+        .opacity(isStale ? 0.6 : 1)
+    }
+
+    private var isUnresolvedAttention: Bool {
+        agent.state.requiresAttention && !agent.isAcknowledged
+    }
+
+    /// Refresh cadence per state; nil renders statically.
+    private var tick: TimeInterval? {
+        switch agent.state {
+        case .working: 0.12
+        case .waitingForInput, .approvalRequired: isUnresolvedAttention ? 0.1 : nil
+        case .failed: isUnresolvedAttention ? 0.15 : nil
+        default: nil
+        }
+    }
+
+    private func led(at time: TimeInterval?) -> some View {
+        let style = ledStyle(at: time)
+        return Circle()
+            .fill(style.color.opacity(style.brightness))
+            .frame(width: Self.diameter, height: Self.diameter)
+            .shadow(color: style.color.opacity(style.brightness * 0.9), radius: 3)
+    }
+
+    private func ledStyle(at time: TimeInterval?) -> (color: Color, brightness: Double) {
+        switch agent.state {
+        case .working:
+            guard let time else { return (LEDPalette.cyan, 0.9) }
+            return (LEDPalette.cyan, 0.45 + 0.55 * (sin(time * 2.4) + 1) / 2)
+
+        case .waitingForInput, .approvalRequired:
+            guard isUnresolvedAttention else { return (.orange, 0.55) }
+            guard let time else { return (.orange, 1) }
+            return (.orange, 0.55 + 0.4 * (sin(time * 3) + 1) / 2)
+
+        case .failed:
+            guard isUnresolvedAttention else { return (LEDPalette.red, 0.5) }
+            guard let time else { return (LEDPalette.red, 1) }
+            // Double-blink, then a dim hold before repeating (matches the strip).
+            let cycle = time.truncatingRemainder(dividingBy: 1.2)
+            let on = cycle < 0.15 || (0.3..<0.45).contains(cycle)
+            return (LEDPalette.red, on ? 1 : 0.18)
+
+        case .completed:
+            return (LEDPalette.green, 0.95)
+
+        case .idle:
+            return (LEDPalette.cyan, 0.22)
+
+        case .disconnected:
+            return (.gray, 0.3)
+
+        case .unknown:
+            return (.white, 0.12)
+        }
+    }
+}

--- a/Sources/AIPulse/Presentation/Pill/LightStripView.swift
+++ b/Sources/AIPulse/Presentation/Pill/LightStripView.swift
@@ -15,8 +15,18 @@ import AIPulseKit
 /// Animations step at LED-refresh cadence via TimelineView(.periodic) —
 /// deliberately not display-refresh — and Reduce Motion replaces every
 /// pattern with a static treatment.
+/// Palette from the inspiration: #26d8ff comet, #30d158 success, #ff2d20
+/// error. Shared with the per-agent lights so both styles speak one language.
+enum LEDPalette {
+    static let cyan = Color(red: 0.15, green: 0.85, blue: 1.0)
+    static let auroraBlue = Color(red: 0.23, green: 0.42, blue: 1.0)
+    static let green = Color(red: 0.19, green: 0.82, blue: 0.35)
+    static let red = Color(red: 1.0, green: 0.18, blue: 0.13)
+}
+
 struct LightStripView: View {
     let signal: LightSignal
+    var background: PillBackgroundStyle = .dark
     /// Renders the strip at a fixed animation time instead of live-ticking.
     /// Headless frame rendering only (docs/marketing assets); the app always
     /// leaves this nil.
@@ -26,12 +36,6 @@ struct LightStripView: View {
 
     private static let ledCount = 8
     private static let cometTail = 3
-
-    // Palette from the inspiration: #26d8ff comet, #30d158 success, #ff2d20 error.
-    private static let cyan = Color(red: 0.15, green: 0.85, blue: 1.0)
-    private static let auroraBlue = Color(red: 0.23, green: 0.42, blue: 1.0)
-    private static let green = Color(red: 0.19, green: 0.82, blue: 0.35)
-    private static let red = Color(red: 1.0, green: 0.18, blue: 0.13)
 
     var body: some View {
         Group {
@@ -73,10 +77,27 @@ struct LightStripView: View {
         }
         .padding(.horizontal, 10)
         .frame(height: 20)
-        .background(Capsule().fill(Color.black.opacity(0.88)))
-        .overlay(Capsule().strokeBorder(Color.white.opacity(0.12)))
+        .background {
+            switch background {
+            case .dark:
+                Capsule().fill(Color.black.opacity(0.88))
+            case .translucent:
+                ZStack {
+                    Capsule().fill(.regularMaterial)
+                    // LEDs need some darkness behind them to glow.
+                    Capsule().fill(Color.black.opacity(0.35))
+                }
+            case .transparent:
+                EmptyView()
+            }
+        }
+        .overlay {
+            if background != .transparent {
+                Capsule().strokeBorder(Color.white.opacity(0.12))
+            }
+        }
         .compositingGroup()
-        .shadow(color: .black.opacity(0.3), radius: 4, y: 1)
+        .shadow(color: .black.opacity(background == .transparent ? 0 : 0.3), radius: 4, y: 1)
     }
 
     private func ledStyle(index: Int, time: TimeInterval?) -> (color: Color, brightness: Double) {
@@ -85,16 +106,16 @@ struct LightStripView: View {
             return (.white, 0.05)
 
         case .idle:
-            guard let time else { return (Self.cyan, 0.22) }
+            guard let time else { return (LEDPalette.cyan, 0.22) }
             let phase = time / 3 + Double(index) * 0.45
             let mix = (sin(phase) + 1) / 2
-            let color = Self.blend(Self.cyan, Self.auroraBlue, mix)
+            let color = Self.blend(LEDPalette.cyan, LEDPalette.auroraBlue, mix)
             return (color, 0.18 + 0.14 * (sin(phase + 1.3) + 1) / 2)
 
         case .working:
             guard let time else {
                 // Static: a lit center segment.
-                return (3...5).contains(index) ? (Self.cyan, 0.9) : (Self.cyan, 0.1)
+                return (3...5).contains(index) ? (LEDPalette.cyan, 0.9) : (LEDPalette.cyan, 0.1)
             }
             // Comet: head wraps past the strip so the tail fully exits.
             let head = Int(time / 0.12) % (Self.ledCount + Self.cometTail + 1)
@@ -106,21 +127,21 @@ struct LightStripView: View {
             case 3: 0.12
             default: 0.06
             }
-            return (Self.cyan, brightness)
+            return (LEDPalette.cyan, brightness)
 
         case .attention:
             guard let time else { return (.orange, 1) }
             return (.orange, 0.55 + 0.4 * (sin(time * 3) + 1) / 2)
 
         case .failure:
-            guard let time else { return (Self.red, 1) }
+            guard let time else { return (LEDPalette.red, 1) }
             // Double-blink, then a dim hold before repeating.
             let cycle = time.truncatingRemainder(dividingBy: 1.2)
             let on = cycle < 0.15 || (0.3..<0.45).contains(cycle)
-            return (Self.red, on ? 1 : 0.18)
+            return (LEDPalette.red, on ? 1 : 0.18)
 
         case .success:
-            return (Self.green, 0.95)
+            return (LEDPalette.green, 0.95)
         }
     }
 

--- a/Sources/AIPulse/Presentation/Pill/PillView.swift
+++ b/Sources/AIPulse/Presentation/Pill/PillView.swift
@@ -62,7 +62,10 @@ struct PillView: View {
 
     /// Aggregate LED strip: one light bar for all agents.
     private var lightStrip: some View {
-        LightStripView(signal: LightAggregator.signal(for: store.pillAgents))
+        LightStripView(
+            signal: LightAggregator.signal(for: store.pillAgents, order: store.statePriority),
+            background: appearance.pillBackground
+        )
             .contentShape(Capsule())
             .onTapGesture {
                 coordinator.showAgentList()
@@ -91,7 +94,6 @@ struct PillView: View {
                 AgentIconButton(
                     agent: agent,
                     isStale: store.staleAgentIDs.contains(agent.id),
-                    standalone: appearance.pillBackground == .transparent,
                     coordinator: coordinator
                 )
             }
@@ -102,7 +104,7 @@ struct PillView: View {
             }
         }
         .padding(.horizontal, 9)
-        .frame(height: 36)
+        .frame(height: 28)
         .background {
             // ultraThin let bright wallpapers wash the pill out; a heavier
             // material plus a scrim keeps icon contrast stable regardless
@@ -148,13 +150,10 @@ struct PillView: View {
 struct AgentIconButton: View {
     let agent: Agent
     var isStale: Bool = false
-    /// True when the pill has no capsule background (transparent style), so
-    /// each icon needs its own backing to stand out from the wallpaper.
-    var standalone: Bool = false
     let coordinator: PillCoordinator
 
     var body: some View {
-        AgentStatusIcon(agent: agent, isStale: isStale, standalone: standalone)
+        AgentLightView(agent: agent, isStale: isStale)
             .contentShape(Circle())
             .onTapGesture {
                 coordinator.agentClicked(agent)

--- a/Sources/AIPulse/Presentation/Settings/SettingsWindowController.swift
+++ b/Sources/AIPulse/Presentation/Settings/SettingsWindowController.swift
@@ -140,7 +140,7 @@ struct SettingsView: View {
                         Text(style.label).tag(style)
                     }
                 }
-                Text("Lights shows one aggregate LED strip for all agents; Agent icons shows one icon per session.")
+                Text("Lights shows one aggregate LED strip for all agents; Agent lights shows one light per session.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Picker("Pill background", selection: $appearance.pillBackground) {
@@ -148,7 +148,7 @@ struct SettingsView: View {
                         Text(style.label).tag(style)
                     }
                 }
-                Text("Transparent removes the capsule so only the agent icons float beside the Dock.")
+                Text("Transparent removes the capsule so only the lights float beside the Dock.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Toggle("Show floating pill", isOn: $appearance.showPill)
@@ -176,6 +176,40 @@ struct SettingsView: View {
                     Text("Never").tag(-1.0)
                 }
                 Text("A working agent whose process has exited is disconnected immediately; silence alone disconnects it after this delay. Waiting, approval, and failed states stay visible until resolved or acknowledged.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Section("State priority") {
+                ForEach(Array(behavior.statePriorityOrder.enumerated()), id: \.element) { index, state in
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(state.tint)
+                            .frame(width: 8, height: 8)
+                        Text(sentenceCase(state.displayLabel))
+                        Spacer()
+                        Button {
+                            movePriority(at: index, by: -1)
+                        } label: {
+                            Image(systemName: "chevron.up")
+                        }
+                        .buttonStyle(.borderless)
+                        .disabled(index == 0)
+                        .accessibilityLabel("Move \(state.displayLabel) up")
+                        Button {
+                            movePriority(at: index, by: 1)
+                        } label: {
+                            Image(systemName: "chevron.down")
+                        }
+                        .buttonStyle(.borderless)
+                        .disabled(index == behavior.statePriorityOrder.count - 1)
+                        .accessibilityLabel("Move \(state.displayLabel) down")
+                    }
+                }
+                Button("Reset to Default") {
+                    behavior.statePriorityOrder = StatusPriority.defaultOrder
+                }
+                .disabled(behavior.statePriorityOrder == StatusPriority.defaultOrder)
+                Text("Most important first. When agents are in different states, the lights strip and Dock icon show the highest state present, and agent icons sort in this order.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -212,12 +246,27 @@ struct SettingsView: View {
         .onChange(of: behavior.staleness) {
             coordinator.behaviorSettingsChanged()
         }
+        .onChange(of: behavior.statePriorityOrder) {
+            coordinator.statePriorityChanged(behavior.statePriorityOrder)
+        }
         .onChange(of: appearance.showDockIcon) {
             coordinator.presentationChanged(showDockIcon: appearance.showDockIcon, showPill: appearance.showPill)
         }
         .onChange(of: appearance.showPill) {
             coordinator.presentationChanged(showDockIcon: appearance.showDockIcon, showPill: appearance.showPill)
         }
+    }
+
+    private func movePriority(at index: Int, by offset: Int) {
+        var order = behavior.statePriorityOrder
+        let target = index + offset
+        guard order.indices.contains(index), order.indices.contains(target) else { return }
+        order.swapAt(index, target)
+        behavior.statePriorityOrder = order
+    }
+
+    private func sentenceCase(_ label: String) -> String {
+        label.prefix(1).uppercased() + label.dropFirst()
     }
 
     private func applyPort() {

--- a/Sources/AIPulseKit/Domain/StatusPriority.swift
+++ b/Sources/AIPulseKit/Domain/StatusPriority.swift
@@ -1,26 +1,35 @@
 import Foundation
 
-/// Urgency ordering for agent states. Lower rank means more urgent.
+/// Urgency ordering for agent states. Lower rank means more urgent. Every
+/// surface (icon sort, lights aggregation, Dock tile) derives from one order
+/// so they never disagree; users can rearrange it in Settings.
 public enum StatusPriority {
-    public static func rank(_ state: AgentState) -> Int {
-        switch state {
-        case .approvalRequired: 0
-        case .waitingForInput: 1
-        case .failed: 2
-        case .working: 3
-        case .completed: 4
-        case .disconnected: 5
-        case .idle: 6
-        case .unknown: 7
-        }
+    /// Built-in order, most urgent first.
+    public static let defaultOrder: [AgentState] = [
+        .approvalRequired, .waitingForInput, .failed, .working,
+        .completed, .disconnected, .idle, .unknown,
+    ]
+
+    /// Repairs an arbitrary order into a full permutation: drops duplicates,
+    /// then appends missing states in default position. Keeps stored
+    /// preferences valid when states are added in a later version.
+    public static func normalize(_ order: [AgentState]) -> [AgentState] {
+        var seen = Set<AgentState>()
+        var result = order.filter { seen.insert($0).inserted }
+        result.append(contentsOf: defaultOrder.filter { !seen.contains($0) })
+        return result
+    }
+
+    public static func rank(_ state: AgentState, order: [AgentState] = defaultOrder) -> Int {
+        order.firstIndex(of: state) ?? order.count
     }
 
     /// Sorts by urgency, then most recent state transition, then stable ID so
     /// equal-priority agents never reorder arbitrarily between renders.
-    public static func sort(_ agents: [Agent]) -> [Agent] {
+    public static func sort(_ agents: [Agent], order: [AgentState] = defaultOrder) -> [Agent] {
         agents.sorted { a, b in
-            let ra = rank(a.state)
-            let rb = rank(b.state)
+            let ra = rank(a.state, order: order)
+            let rb = rank(b.state, order: order)
             if ra != rb { return ra < rb }
             if a.stateChangedAt != b.stateChangedAt { return a.stateChangedAt > b.stateChangedAt }
             return a.id < b.id

--- a/Sources/AIPulseKit/Store/AgentStore.swift
+++ b/Sources/AIPulseKit/Store/AgentStore.swift
@@ -12,16 +12,20 @@ public final class AgentStore {
     /// IDs of agents currently considered stale, refreshed by `sweep`.
     public private(set) var staleAgentIDs: Set<String> = []
 
+    /// Display priority every surface derives from, most urgent first.
+    /// The app layer overwrites this from user settings.
+    public var statePriority: [AgentState] = StatusPriority.defaultOrder
+
     public init() {}
 
     /// All agents, urgency-sorted with stable tie-breaking.
     public var allSorted: [Agent] {
-        StatusPriority.sort(Array(agentsByID.values))
+        StatusPriority.sort(Array(agentsByID.values), order: statePriority)
     }
 
     /// Agents eligible for the pill (muted agents stay in the list window only).
     public var pillAgents: [Agent] {
-        StatusPriority.sort(agentsByID.values.filter { !$0.isMuted })
+        StatusPriority.sort(agentsByID.values.filter { !$0.isMuted }, order: statePriority)
     }
 
     /// Splits pill agents into the visible slice and an overflow count.

--- a/Sources/AIPulseKit/Store/DockTileAggregator.swift
+++ b/Sources/AIPulseKit/Store/DockTileAggregator.swift
@@ -23,19 +23,29 @@ public struct DockTileSummary: Sendable, Equatable {
 }
 
 public enum DockTileAggregator {
-    public static func summarize(_ agents: [Agent]) -> DockTileSummary {
+    public static func summarize(
+        _ agents: [Agent],
+        order: [AgentState] = StatusPriority.defaultOrder
+    ) -> DockTileSummary {
         let unacknowledged = agents.filter { $0.state.requiresAttention && !$0.isAcknowledged }
         let urgentCount = unacknowledged.count
 
-        let emphasis: DockTileEmphasis
-        if unacknowledged.contains(where: { $0.state == .failed }) {
-            emphasis = .failure
-        } else if !unacknowledged.isEmpty {
-            emphasis = .attention
-        } else if agents.contains(where: { $0.state == .working }) {
-            emphasis = .working
-        } else {
-            emphasis = .neutral
+        var emphasis: DockTileEmphasis = .neutral
+        for state in order {
+            let candidate: DockTileEmphasis? = switch state {
+            case .failed:
+                unacknowledged.contains { $0.state == .failed } ? .failure : nil
+            case .waitingForInput, .approvalRequired:
+                unacknowledged.contains { $0.state == state } ? .attention : nil
+            case .working:
+                agents.contains { $0.state == .working } ? .working : nil
+            default:
+                nil
+            }
+            if let candidate {
+                emphasis = candidate
+                break
+            }
         }
         return DockTileSummary(emphasis: emphasis, urgentCount: urgentCount)
     }

--- a/Sources/AIPulseKit/Store/LightAggregator.swift
+++ b/Sources/AIPulseKit/Store/LightAggregator.swift
@@ -18,21 +18,33 @@ public enum LightSignal: String, Sendable, Equatable {
 }
 
 public enum LightAggregator {
-    public static func signal(for agents: [Agent]) -> LightSignal {
-        if agents.contains(where: { $0.state == .failed && !$0.isAcknowledged }) {
-            return .failure
-        }
-        if agents.contains(where: {
-            ($0.state == .waitingForInput || $0.state == .approvalRequired) && !$0.isAcknowledged
-        }) {
-            return .attention
-        }
-        if agents.contains(where: { $0.state == .working }) {
-            return .working
-        }
-        if agents.contains(where: { $0.state == .completed }) {
-            return .success
+    public static func signal(
+        for agents: [Agent],
+        order: [AgentState] = StatusPriority.defaultOrder
+    ) -> LightSignal {
+        for state in order {
+            guard let candidate = signal(for: state) else { continue }
+            // Attention-type states stay quiet once acknowledged; a strip
+            // that kept shouting after "got it" would train users to ignore it.
+            let matches = if state.requiresAttention {
+                agents.contains { $0.state == state && !$0.isAcknowledged }
+            } else {
+                agents.contains { $0.state == state }
+            }
+            if matches { return candidate }
         }
         return agents.isEmpty ? .off : .idle
+    }
+
+    /// The signal a state raises when it wins the priority scan; nil for
+    /// states that only contribute to the idle/off fallback.
+    private static func signal(for state: AgentState) -> LightSignal? {
+        switch state {
+        case .failed: .failure
+        case .waitingForInput, .approvalRequired: .attention
+        case .working: .working
+        case .completed: .success
+        case .idle, .disconnected, .unknown: nil
+        }
     }
 }

--- a/Tests/AIPulseKitTests/DockTileAggregatorTests.swift
+++ b/Tests/AIPulseKitTests/DockTileAggregatorTests.swift
@@ -27,12 +27,28 @@ final class DockTileAggregatorTests: XCTestCase {
         XCTAssertEqual(summary.urgentCount, 1)
     }
 
-    func testFailureBeatsAttention() {
+    /// The default order ranks actionable states (approval, waiting) above
+    /// failed, matching StatusPriority.defaultOrder.
+    func testAttentionOutranksFailureByDefault() {
         let summary = DockTileAggregator.summarize([
             agent("a", .waitingForInput), agent("b", .failed), agent("c", .approvalRequired),
         ])
-        XCTAssertEqual(summary.emphasis, .failure)
+        XCTAssertEqual(summary.emphasis, .attention)
         XCTAssertEqual(summary.urgentCount, 3)
+    }
+
+    func testFailureBeatsWorking() {
+        let summary = DockTileAggregator.summarize([agent("a", .working), agent("b", .failed)])
+        XCTAssertEqual(summary.emphasis, .failure)
+        XCTAssertEqual(summary.urgentCount, 1)
+    }
+
+    func testCustomOrderRestoresFailureFirst() {
+        let summary = DockTileAggregator.summarize(
+            [agent("a", .waitingForInput), agent("b", .failed)],
+            order: StatusPriority.normalize([.failed])
+        )
+        XCTAssertEqual(summary.emphasis, .failure)
     }
 
     func testAcknowledgedAgentsDoNotCount() {

--- a/Tests/AIPulseKitTests/LightAggregatorTests.swift
+++ b/Tests/AIPulseKitTests/LightAggregatorTests.swift
@@ -42,11 +42,41 @@ final class LightAggregatorTests: XCTestCase {
         )
     }
 
-    func testFailureBeatsEverything() {
+    func testFailureBeatsWorkingAndSuccess() {
+        XCTAssertEqual(
+            LightAggregator.signal(for: [
+                agent("a", .working), agent("b", .completed), agent("c", .failed),
+            ]),
+            .failure
+        )
+    }
+
+    /// The default order ranks actionable states (approval, waiting) above
+    /// failed, matching StatusPriority.defaultOrder.
+    func testAttentionOutranksFailureByDefault() {
         XCTAssertEqual(
             LightAggregator.signal(for: [
                 agent("a", .working), agent("b", .waitingForInput), agent("c", .failed),
             ]),
+            .attention
+        )
+    }
+
+    func testCustomOrderPromotesCompletedOverWorking() {
+        let order = StatusPriority.normalize([.completed])
+        XCTAssertEqual(
+            LightAggregator.signal(for: [agent("a", .working), agent("b", .completed)], order: order),
+            .success
+        )
+    }
+
+    func testCustomOrderRestoresFailureFirst() {
+        let order = StatusPriority.normalize([.failed])
+        XCTAssertEqual(
+            LightAggregator.signal(
+                for: [agent("a", .waitingForInput), agent("b", .failed)],
+                order: order
+            ),
             .failure
         )
     }
@@ -68,7 +98,7 @@ final class LightAggregatorTests: XCTestCase {
         store.upsert(agent("a", .waitingForInput))
         store.upsert(agent("b", .failed))
         store.upsert(agent("c", .working))
-        XCTAssertEqual(LightAggregator.signal(for: store.allSorted), .failure)
+        XCTAssertEqual(LightAggregator.signal(for: store.allSorted), .attention)
 
         store.acknowledgeAll()
         XCTAssertEqual(LightAggregator.signal(for: store.allSorted), .working)

--- a/Tests/AIPulseKitTests/StatusPriorityTests.swift
+++ b/Tests/AIPulseKitTests/StatusPriorityTests.swift
@@ -33,6 +33,26 @@ final class StatusPriorityTests: XCTestCase {
         ])
     }
 
+    func testCustomOrderChangesRankAndSort() {
+        let order = StatusPriority.normalize([.completed, .failed])
+        XCTAssertEqual(StatusPriority.rank(.completed, order: order), 0)
+        XCTAssertEqual(StatusPriority.rank(.failed, order: order), 1)
+        let sorted = StatusPriority.sort(
+            [agent("a", .working), agent("b", .completed)],
+            order: order
+        ).map(\.state)
+        XCTAssertEqual(sorted, [.completed, .working])
+    }
+
+    func testNormalizeRepairsPartialAndDuplicateOrders() {
+        XCTAssertEqual(StatusPriority.normalize([]), StatusPriority.defaultOrder)
+        XCTAssertEqual(
+            StatusPriority.normalize([.completed, .completed, .failed]),
+            [.completed, .failed, .approvalRequired, .waitingForInput, .working, .disconnected, .idle, .unknown]
+        )
+        XCTAssertEqual(Set(StatusPriority.normalize([.idle])), Set(AgentState.allCases))
+    }
+
     func testSamePrioritySortsByMostRecentTransition() {
         let older = agent("older", .working, changedAt: Date(timeIntervalSince1970: 100))
         let newer = agent("newer", .working, changedAt: Date(timeIntervalSince1970: 200))


### PR DESCRIPTION
## What

### Configurable state priority (Settings → State priority)
When multiple agents are in different states, the app previously picked what to show from three independent hardcoded orderings (`StatusPriority`, `LightAggregator`, `DockTileAggregator`). This PR unifies them behind one most-urgent-first order the user can rearrange in Settings (up/down per state, reset to default). The order drives:

- icon/light sorting in the pill and which agents survive the 6-slot overflow cutoff,
- which single state the lights strip shows,
- the Dock tile emphasis.

Stored in `UserDefaults` (`behavior.statePriority`), pushed into `AgentStore.statePriority`, applied live via observation. Stored orders are normalized on load (dedup + append missing states), so adding states in a future version can't break saved preferences.

**Behavior change:** the surfaces previously disagreed — sorting ranked approval/waiting above failed, while lights/Dock ranked failed first. The unified default follows the sort order, so with both a failed and a waiting agent present the strip now shows attention (orange) instead of failure (red). Rationale: waiting states are actionable right now. Users who prefer the old precedence can move Failed to the top.

### Per-agent lights ("Agent lights" style)
The per-agent style no longer renders provider icons with state badges — each agent is a single LED (`AgentLightView`) sharing the aggregate strip's palette and animation language: cyan pulse working, orange breathe waiting/approval (dims solid once acknowledged), red double-blink failed, solid green completed. Click/hover/context menu unchanged; VoiceOver still announces full state. The agent list window keeps the detailed icons.

### Pill background fixes
The lights strip ignored the background setting and always drew its own dark capsule. It now honors Dark / Translucent / Transparent (transparent floats bare LEDs, whose glow keeps them visible).

### Dock tile
- Draws the real app icon instead of placeholder art. Loads the raw `AppIcon.icns` from the bundle because `NSApp.applicationIconImage` on macOS 26+ wraps non-squircle legacy icons in a gray rounded-square backdrop.
- Corner glyphs (`?`, `!`, arrows) removed. The corner dot now appears only for *working* — attention/failure are already conveyed by the numeric badge, so a second marker was redundant.

### Version stamping
`make-app.sh` stamped hardcoded `0.1.0` into local builds (releases pass `AIPULSE_VERSION`). Local builds now use `git describe --tags --dirty`, so Settings shows e.g. `0.3.2-dirty`.

## Tests
All 129 pass. Updated the aggregator tests encoding the old failure-first precedence, added coverage for custom orders and `normalize`.

## Related
Follow-up ideas for showing multiple states simultaneously (segmented strip etc.): #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)